### PR TITLE
feat: Mark members with cards on table

### DIFF
--- a/apps/frontend/src/routes/room.vue
+++ b/apps/frontend/src/routes/room.vue
@@ -34,7 +34,8 @@
                     </li>
                     <li v-for="member in $store.getters.members.filter(mem => mem.name != '')" :key="member.id">
                         <c-text :class="member.id !== me.id || 'b'">
-                            <i class="fa fa-user"></i> 
+                            <template v-if="member.card"><i class="fa fa-check"></i></template>
+                            <template v-else><i class=" fa fa-user"></i></template>
                             <template v-if="member.name">{{' '}}{{member.name}}</template>
                             <template v-else> No name</template>
                         </c-text>
@@ -146,4 +147,7 @@ li {
     justify-content: space-around;
 }
 
+.fa-check {
+    color: green;
+}
 </style>


### PR DESCRIPTION
This PR will add support to show an indicator next to the members who currently have cards on the table.

---
Thanks for this great tool, really appreciated!

I've noticed when the number of participants increases it's getting harder to see when everyone have put their card on the table. This will not change the possibility to sit out, it will just make it easier to spot who have put a card on the table.

<img width="605" alt="image" src="https://user-images.githubusercontent.com/3248948/216478513-20285f4a-4a46-467d-8c79-770eb1a0542b.png">
